### PR TITLE
Add PostgreSQL docker service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 - Adds first version
+- Added PostgreSQL database service support

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Dockerizer provides a streamlined workflow to containerize your PHP application 
 ### Modular Service Classes
 - Each Docker service (App, Nginx, Database, Redis, Worker, Scheduler) is encapsulated in its own class.
 - Only services enabled in your configuration are included in the generated compose file.
+- Supports MySQL and PostgreSQL database containers out of the box.
 - Easily extendable for additional services.
 
 ---

--- a/src/Enums/DatabaseOptions.php
+++ b/src/Enums/DatabaseOptions.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace SvenVanderwegen\Dockerizer\Enums;
 
 use SvenVanderwegen\Dockerizer\Services\MySQLDockerService;
+use SvenVanderwegen\Dockerizer\Services\PostgresDockerService;
 
 enum DatabaseOptions: string
 {
@@ -48,7 +49,7 @@ enum DatabaseOptions: string
     {
         return match ($this) {
             self::MYSQL => MySQLDockerService::class,
-            self::POSTGRESQL => null, // TODO: implement PostgreSQL docker service
+            self::POSTGRESQL => PostgresDockerService::class,
             self::SQLITE => null,
         };
     }

--- a/src/Services/PostgresDockerService.php
+++ b/src/Services/PostgresDockerService.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SvenVanderwegen\Dockerizer\Services;
+
+use SvenVanderwegen\Dockerizer\Contracts\DockerServiceModule;
+
+final class PostgresDockerService implements DockerServiceModule
+{
+    public function getServiceName(): string
+    {
+        return 'db';
+    }
+
+    public function getServiceImage(): string
+    {
+        return 'postgres:16';
+    }
+
+    public function getService(): DockerService
+    {
+        return new DockerService(
+            image: $this->getServiceImage(),
+            restart: 'unless-stopped',
+            environment: [
+                'POSTGRES_DB' => 'laravel',
+                'POSTGRES_USER' => 'laravel',
+                'POSTGRES_PASSWORD' => 'secret',
+            ],
+            volumes: [
+                'db-data:/var/lib/postgresql/data',
+            ],
+            networks: [
+                'internal',
+            ],
+        );
+    }
+}

--- a/tests/Feature/PostgresServiceTest.php
+++ b/tests/Feature/PostgresServiceTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use SvenVanderwegen\Dockerizer\Commands\DockerizerBuildCommand;
+use SvenVanderwegen\Dockerizer\Services\PostgresDockerService;
+use SvenVanderwegen\Dockerizer\Support\ConfigurationService;
+use SvenVanderwegen\Dockerizer\Support\ConfigHelper;
+
+it('includes postgres service when database.type is postgresql', function () {
+    config()->set('dockerizer.directory', 'temp');
+
+    $service = new ConfigurationService();
+    $service->saveConfiguration([
+        'database' => ['type' => 'postgresql'],
+        'services' => [
+            'redis' => false,
+            'workers' => false,
+            'scheduler' => false,
+        ],
+        'registry' => [
+            'type' => 'dockerhub',
+            'repository' => 'demo',
+            'url' => null,
+        ],
+    ]);
+
+    $helper = new ConfigHelper($service);
+    app()->instance(ConfigHelper::class, $helper);
+
+    $command = new DockerizerBuildCommand();
+    $ref = new ReflectionMethod($command, 'collectDockerServices');
+    $ref->setAccessible(true);
+
+    $services = $ref->invoke($command);
+
+    expect($services)->toContain(PostgresDockerService::class);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,5 @@
+<?php
+
+use Tests\TestCase;
+
+uses(TestCase::class)->in(__DIR__);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests;
+
+use Orchestra\Testbench\TestCase as BaseTestCase;
+use SvenVanderwegen\Dockerizer\DockerizerServiceProvider;
+
+class TestCase extends BaseTestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [DockerizerServiceProvider::class];
+    }
+}

--- a/tests/Unit/DatabaseOptionsTest.php
+++ b/tests/Unit/DatabaseOptionsTest.php
@@ -1,0 +1,9 @@
+<?php
+
+use SvenVanderwegen\Dockerizer\Enums\DatabaseOptions;
+use SvenVanderwegen\Dockerizer\Services\PostgresDockerService;
+
+it('returns Postgres service class for POSTGRESQL option', function () {
+    expect(DatabaseOptions::POSTGRESQL->getDockerService())
+        ->toBe(PostgresDockerService::class);
+});


### PR DESCRIPTION
## Summary
- introduce `PostgresDockerService` mirroring `MySQLDockerService`
- return this new service from `DatabaseOptions::getDockerService`
- document PostgreSQL support in README and CHANGELOG
- provide unit and feature tests for PostgreSQL support

## Testing
- `vendor/bin/pest`

------
https://chatgpt.com/codex/tasks/task_e_6840ad13ce688324836ac6e26c76a392