### PR TITLE
Replace placeholder tests with Pest suite

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ composer lint
 
 Run all tests:
 ```bash
-composer test
+XDEBUG_MODE=coverage composer test
 ```
 
 Check types:
@@ -43,5 +43,5 @@ composer test:types
 
 Unit tests:
 ```bash
-composer test:unit
+XDEBUG_MODE=coverage composer test:unit
 ```

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     },
     "require-dev": {
         "laravel/pint": "^1.18.1",
+        "mockery/mockery": "^1.6",
         "orchestra/canvas": "^10.0",
         "pestphp/pest": "^3.5.1",
         "pestphp/pest-plugin-type-coverage": "^3.1",

--- a/tests/DockerizerBuildCommandTest.php
+++ b/tests/DockerizerBuildCommandTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+use Symfony\Component\Console\Command\Command;
+
+it('generates docker files', function () {
+    $basePath = $this->basePath;
+    File::ensureDirectoryExists($basePath.'/.dockerizer');
+
+    $config = [
+        'registry' => [
+            'type' => 'dockerhub',
+            'repository' => 'user/app',
+            'url' => null,
+        ],
+        'database' => [
+            'type' => 'mysql',
+            'username' => 'laravel',
+            'password' => 'secret',
+        ],
+        'services' => [
+            'redis' => true,
+            'workers' => true,
+            'scheduler' => false,
+        ],
+    ];
+
+    File::put($basePath.'/.dockerizer/config.json', json_encode($config, JSON_PRETTY_PRINT));
+
+    $this->artisan('dockerizer:build')->assertExitCode(Command::SUCCESS);
+
+    expect(File::exists($basePath.'/.dockerizer/app/Dockerfile'))->toBeTrue()
+        ->and(File::exists($basePath.'/.dockerizer/app/entrypoint.sh'))->toBeTrue()
+        ->and(File::exists($basePath.'/.dockerizer/nginx/Dockerfile'))->toBeTrue()
+        ->and(File::exists($basePath.'/.dockerizer/nginx/default.conf'))->toBeTrue()
+        ->and(File::exists($basePath.'/docker-compose.yml'))->toBeTrue();
+});

--- a/tests/DockerizerSetupCommandTest.php
+++ b/tests/DockerizerSetupCommandTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\File;
+use SvenVanderwegen\Dockerizer\Enums\DatabaseOptions;
+use SvenVanderwegen\Dockerizer\Enums\RegistryOptions;
+use Symfony\Component\Console\Command\Command;
+
+it('creates configuration file', function () {
+    $basePath = $this->basePath;
+
+    $this->artisan('dockerizer:setup')
+        ->expectsChoice(
+            'Which container registry do you want to use?',
+            'dockerhub',
+            RegistryOptions::choices()
+        )
+        ->expectsQuestion('Enter your repository path (e.g., myusername/myapp)', 'user/app')
+        ->expectsChoice(
+            'Which database do you want to use?',
+            DatabaseOptions::SQLITE->value,
+            DatabaseOptions::choices()
+        )
+        ->expectsConfirmation('Do you want to use Redis?', 'yes')
+        ->expectsConfirmation('Do you want to add a queue worker?', 'yes')
+        ->expectsConfirmation('Do you want to add a scheduler container?', 'no')
+        ->assertExitCode(Command::SUCCESS);
+
+    $configFile = $basePath.'/.dockerizer/config.json';
+    expect(File::exists($configFile))->toBeTrue();
+
+    $config = json_decode(File::get($configFile), true);
+
+    expect($config['registry']['repository'])->toBe('user/app')
+        ->and($config['services']['redis'])->toBeTrue();
+});

--- a/tests/Feature.php
+++ b/tests/Feature.php
@@ -1,3 +1,0 @@
-<?php
-
-declare(strict_types=1);

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+use Tests\TestCase;
+
+uses(TestCase::class)->in(__DIR__);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests;
+
+use Orchestra\Testbench\TestCase as BaseTestCase;
+use SvenVanderwegen\Dockerizer\DockerizerServiceProvider;
+
+abstract class TestCase extends BaseTestCase
+{
+    protected string $basePath;
+
+    protected function setUp(): void
+    {
+        $this->basePath = sys_get_temp_dir().'/dockerizer-test-'.uniqid();
+        mkdir($this->basePath.'/bootstrap/cache', 0777, true);
+        $_ENV['APP_BASE_PATH'] = $this->basePath;
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->basePath)) {
+            passthru('rm -rf '.escapeshellarg($this->basePath));
+        }
+
+        parent::tearDown();
+    }
+    protected function getPackageProviders($app)
+    {
+        return [DockerizerServiceProvider::class];
+    }
+}


### PR DESCRIPTION
## Summary
- add Pest TestCase and tests for setup/build commands
- require mockery for command interaction
- document running tests with coverage
- remove placeholder Feature test

## Testing
- `composer lint`
- `composer test` *(fails: Code coverage below expected 100%)*

------
https://chatgpt.com/codex/tasks/task_e_6840ad15b45c83248454584f48543948